### PR TITLE
chore: update lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5369,9 +5369,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "he": "^0.5.0",
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.20",
     "traverse": "^0.6.6"
   }
 }


### PR DESCRIPTION
bump lodash up to most recent release, 4.17.20 (various security issues with < 4.17.20 and prototype pollutionc)