### PR TITLE
Turn off strict decoding

### DIFF
--- a/__tests__/get.test.js
+++ b/__tests__/get.test.js
@@ -5,6 +5,7 @@ var base = require('./samples/base-test.json')
 var locale = require('./samples/locale-test.json')
 var client = require('./samples/client-test.json')
 var edges = require('./samples/edge-cases.json')
+var encoded = require('./samples/encoded-test.json')
 
 var builder = require('../lib/builder')
 var get = require('../lib/get')
@@ -13,7 +14,7 @@ var dictionary
 
 describe('get()', () => {
   beforeAll(function () {
-    dictionary = builder.build([base, locale, client, edges])
+    dictionary = builder.build([base, locale, client, edges, encoded])
     get = get.bind(require('../index.js'))
   })
 
@@ -70,4 +71,21 @@ describe('get()', () => {
   test('should retrieve a single char referenced string', () => {
     expect(get(dictionary, 'references.singleChar.t')).toBe('t')
   })
+
+  test('should retrieve and decode html characters', () => {
+    expect(get(dictionary, 'encodedString')).toBe('this&that')
+  })
+
+  test('should retrieve and not decode if an ampersand is used but is not an encoded character', () => {
+    expect(get(dictionary, 'ampersandString')).toBe('this&that')
+  })
+
+  test('should retrieve and encode partially if there is a combination of encoded characters and ampersands', () => {
+    expect(get(dictionary, 'encodedCombination')).toBe('this&that&other')
+  })
+
+  test('should decode substitution where applicable', () => {
+    expect(get(dictionary, 'parameteredEncoded', '&amp;', '&oth')).toBe('this&that&other')
+  })
+
 })

--- a/__tests__/samples/encoded-test.json
+++ b/__tests__/samples/encoded-test.json
@@ -1,0 +1,6 @@
+{
+  "encodedString": "this&amp;that",
+  "ampersandString": "this&that",
+  "encodedCombination": "this&amp;that&other",
+  "parameteredEncoded": "this%sthat%ser"
+}

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -101,7 +101,7 @@ function stripPrintfIndexes (match, p1, p2) {
 }
 
 function decode (string) {
-  return he.decode(string, { strict: true })
+  return he.decode(string, { strict: false })
 }
 
 function printf (string, args) {


### PR DESCRIPTION
Hey @snypelife, i think something changed in the latest version of `he` and we are getting errors when some of our string literals (or substitutions) had ampsersands in them.

See the tests (which some would fail on the current version)

I'm not sure if there was a specific reason for `strict: true` on the decode, but it seems to work well without it

we've had to pin back to 2.1.6 for now